### PR TITLE
Add repo favorites + scoping dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^18.12.0",
-        "@raycast/api": "^1.25.4",
+        "@raycast/api": "^1.36.0",
         "lodash": "^4.17.21",
         "react-dom": "^17.0.2",
         "react-query": "^3.29.0"
@@ -394,9 +394,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.25.4",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.25.4.tgz",
-      "integrity": "sha512-E6uAiUBFBS5eSLxAZO840c37JSrfOqIoQACi62g8H4RDT6cwkSfemhhgJk9hGnDXJ1DaSgCVE8GprdvqCTfZ5Q==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.36.1.tgz",
+      "integrity": "sha512-oRV6he/ENcAtVkmn5251VcGiAlwgH60twGlrgKUV7tGxRiFTgy6Jyc02dIvfM2PYcl8dT8UbIdGnkwFA3W5sPw==",
       "bin": {
         "ray": "bin/ray"
       },
@@ -6834,9 +6834,9 @@
       }
     },
     "@raycast/api": {
-      "version": "1.25.4",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.25.4.tgz",
-      "integrity": "sha512-E6uAiUBFBS5eSLxAZO840c37JSrfOqIoQACi62g8H4RDT6cwkSfemhhgJk9hGnDXJ1DaSgCVE8GprdvqCTfZ5Q==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.36.1.tgz",
+      "integrity": "sha512-oRV6he/ENcAtVkmn5251VcGiAlwgH60twGlrgKUV7tGxRiFTgy6Jyc02dIvfM2PYcl8dT8UbIdGnkwFA3W5sPw==",
       "requires": {}
     },
     "@sindresorhus/is": {

--- a/package.json
+++ b/package.json
@@ -48,14 +48,6 @@
       "mode": "view",
       "keywords": [
         "ghs"
-      ],
-      "preferences": [
-        {
-          "description": "Search favorite repos by default. See the \"Manage Favorite Repos\" command.",
-          "name": "favorites",
-          "title": "Search favorite repos by default",
-          "type": "checkbox"
-        }
       ]
     },
     {
@@ -64,28 +56,6 @@
       "subtitle": "Browse, add and remove GitHub repos from your list of favorites",
       "description": "This command provides a way to browse, add, and remove repos from your list of favorites",
       "icon": "icons/heart.png",
-      "mode": "view",
-      "keywords": [
-        "ghs"
-      ]
-    },
-    {
-      "name": "search-github-favorites",
-      "title": "Search Favorite Issues & PRs",
-      "subtitle": "Search favorite GitHub repos for issues and pull requests",
-      "description": "This command provides a way to search issues and pull requests on GitHub. See also the \"Manage Favorite Repos\" command.",
-      "icon": "icons/issue-opened.png",
-      "mode": "view",
-      "keywords": [
-        "ghs"
-      ]
-    },
-    {
-      "name": "search-github-issues",
-      "title": "Search GitHub Org Issues & PRs",
-      "subtitle": "Search issues and pull requests in the GitHub org",
-      "description": "This command provides a way to search issues and pull requests on GitHub",
-      "icon": "icons/issue-opened.png",
       "mode": "view",
       "keywords": [
         "ghs"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,39 @@
       ]
     },
     {
+      "name": "manage-favorites",
+      "title": "Manage Favorite Repos",
+      "subtitle": "Browse, add and remove GitHub repos from your list of favorites",
+      "description": "This command provides a way to browse, add, and remove repos from your list of favorites",
+      "icon": "icons/heart.png",
+      "mode": "view",
+      "keywords": [
+        "ghs"
+      ]
+    },
+    {
+      "name": "search-github-favorites",
+      "title": "Search Favorite Issues & PRs",
+      "subtitle": "Search favorite GitHub repos for issues and pull requests",
+      "description": "This command provides a way to search issues and pull requests on GitHub. See also the \"Manage Favorite Repos\" command.",
+      "icon": "icons/issue-opened.png",
+      "mode": "view",
+      "keywords": [
+        "ghs"
+      ]
+    },
+    {
+      "name": "search-github-issues",
+      "title": "Search GitHub Org Issues & PRs",
+      "subtitle": "Search issues and pull requests in the GitHub org",
+      "description": "This command provides a way to search issues and pull requests on GitHub",
+      "icon": "icons/issue-opened.png",
+      "mode": "view",
+      "keywords": [
+        "ghs"
+      ]
+    },
+    {
       "name": "search-repos",
       "title": "Search Repositories",
       "subtitle": "Search repositories on GitHub",
@@ -73,9 +106,11 @@
       ]
     }
   ],
+  "module": "esnext",
+  "target": "es2022",
   "dependencies": {
     "@octokit/rest": "^18.12.0",
-    "@raycast/api": "^1.25.4",
+    "@raycast/api": "^1.36.0",
     "lodash": "^4.17.21",
     "react-dom": "^17.0.2",
     "react-query": "^3.29.0"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,14 @@
       "mode": "view",
       "keywords": [
         "ghs"
+      ],
+      "preferences": [
+        {
+          "description": "Search favorite repos by default. See the \"Manage Favorite Repos\" command.",
+          "name": "favorites",
+          "title": "Search favorite repos by default",
+          "type": "checkbox"
+        }
       ]
     },
     {

--- a/src/components/repo-detail.tsx
+++ b/src/components/repo-detail.tsx
@@ -1,4 +1,4 @@
-import {Detail} from '@raycast/api'
+import {List, Detail} from '@raycast/api'
 import {ReactElement} from 'react'
 import {useQuery} from 'react-query'
 import {octokit} from '../lib/octokit'
@@ -6,12 +6,14 @@ import withQueryClient from './with-query-client'
 
 interface Props {
   repo: string
-  actions: ReactElement
+  actions?: ReactElement
+  sidepanel?: boolean
 }
 
 export default withQueryClient(function RepoDetail({
   repo,
-  actions
+  actions,
+  sidepanel
 }: Props): ReactElement {
   const [owner, repoName] = repo.split('/')
 
@@ -33,7 +35,9 @@ export default withQueryClient(function RepoDetail({
     fullMarkdown = `# ${repo}\n\n*...Loading.*`
   }
 
-  return (
+  return sidepanel ? (
+    <List.Item.Detail isLoading={isLoading} markdown={fullMarkdown} />
+  ) : (
     <Detail isLoading={isLoading} markdown={fullMarkdown} actions={actions} />
   )
 })

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -1,8 +1,8 @@
-import {getPreferenceValues, List, ListItemProps} from '@raycast/api'
+import {List, ListItemProps} from '@raycast/api'
 import {ComponentType, Key, ReactElement, useState} from 'react'
 import {QueryKey, useQuery} from 'react-query'
 import {useDebouncedValue} from '../hooks/use-debounced-value'
-import useFavorites from '../hooks/use-favorites'
+import useFavorites, {FavoriteRepoItem} from '../hooks/use-favorites'
 import withQueryClient from './with-query-client'
 
 interface Props<T> {
@@ -12,10 +12,40 @@ interface Props<T> {
   actions: ComponentType<{item: T; query: string}>
   noQuery?: ComponentType<{
     setQuery: (query: string) => void
-    toggleScopeOverride: () => void
-    scopeByFavoriteRepos: boolean
+    searchBarAccessory: ReactElement
   }>
 }
+
+enum RepoScopeOptions {
+  ALL = 0,
+  GITHUB = 1,
+  FAVORITES = 2
+}
+
+const repoScopeOptions = new Map([
+  [
+    RepoScopeOptions.ALL,
+    {
+      title: 'All repos',
+      stringify: () => ''
+    }
+  ],
+  [
+    RepoScopeOptions.GITHUB,
+    {
+      title: 'GitHub org',
+      stringify: () => 'org:github'
+    }
+  ],
+  [
+    RepoScopeOptions.FAVORITES,
+    {
+      title: 'Favorite repos',
+      stringify: (favorites: FavoriteRepoItem[]) =>
+        favorites.reduce((memo, next) => `${memo} repo:${next.full_name}`, '')
+    }
+  ]
+])
 
 export default function Search<T>(props: Props<T>) {
   return <SearchWrapper {...props} />
@@ -25,17 +55,12 @@ export default function Search<T>(props: Props<T>) {
 const SearchWrapper = withQueryClient<Props<any>>(function Search(
   props
 ): ReactElement {
-  const favoritesOnly = getPreferenceValues().favorites
   const {favoriteRepos} = useFavorites()
   const [query, setQuery] = useState('')
-  const [scopeOverride, setScopeOverride] = useState(false)
+  const [scope, setScope] = useState<RepoScopeOptions>(0)
   const [favoriteQuery, setFavoriteQuery] = useState<string | undefined>()
 
-  const scopeByFavoriteRepos = +favoritesOnly + +scopeOverride === 1
-  const repoScope = scopeByFavoriteRepos
-    ? favoriteRepos.reduce((memo, next) => `${memo} repo:${next.full_name}`, '')
-    : ''
-
+  const repoScope = repoScopeOptions.get(scope)?.stringify(favoriteRepos)
   const debouncedQuery = useDebouncedValue(`${repoScope} ${query}`)
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -55,10 +80,9 @@ const SearchWrapper = withQueryClient<Props<any>>(function Search(
           setQuery(query)
           setFavoriteQuery(query)
         }}
-        scopeByFavoriteRepos={scopeByFavoriteRepos}
-        toggleScopeOverride={() => {
-          setScopeOverride(!scopeOverride)
-        }}
+        searchBarAccessory={
+          <RepoScopeSelector setScope={scope => setScope(+scope)} />
+        }
       />
     )
   }
@@ -71,6 +95,9 @@ const SearchWrapper = withQueryClient<Props<any>>(function Search(
         setQuery(text)
         setFavoriteQuery(undefined)
       }}
+      searchBarAccessory={
+        <RepoScopeSelector setScope={scope => setScope(+scope)} />
+      }
     >
       {data?.map(item => {
         const itemProps = props.itemProps(item)
@@ -85,3 +112,27 @@ const SearchWrapper = withQueryClient<Props<any>>(function Search(
     </List>
   )
 })
+
+const RepoScopeSelector = ({
+  setScope
+}: {
+  setScope: (scope: string) => void
+}): ReactElement => {
+  return (
+    <List.Dropdown
+      tooltip="Specify which repos to search"
+      storeValue={true}
+      onChange={newValue => {
+        setScope(newValue)
+      }}
+    >
+      {Array.from(repoScopeOptions, ([key, val]) => (
+        <List.Dropdown.Item
+          key={key}
+          title={val.title}
+          value={key.toString()}
+        />
+      ))}
+    </List.Dropdown>
+  )
+}

--- a/src/hooks/use-favorites.tsx
+++ b/src/hooks/use-favorites.tsx
@@ -1,0 +1,138 @@
+import {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods'
+import {LocalStorage, showToast, Toast} from '@raycast/api'
+import {useState, useEffect, useRef, useCallback} from 'react'
+import {octokit} from '../lib/octokit'
+import {Repo} from '../search-repos'
+
+type RepoSingle = RestEndpointMethodTypes['repos']['get']['response']['data']
+
+const KEY = 'favorite-repos'
+
+type UseFavorites = {
+  addFavorite: (repo: Repo | RepoSingle) => void
+  addFavoriteFromQuery: (query: string) => void
+  favoriteRepos: FavoriteRepoItem[]
+  isFavorite: (repo: Repo) => boolean
+  isFavoritable: (query: string) => boolean
+  removeFavorite: (repo: Repo | FavoriteRepoItem) => void
+}
+
+type HttpError = {
+  status: number
+  message: string
+}
+
+export type FavoriteRepoItem = {
+  id: number
+  full_name: string
+  html_url: string
+  avatar_url?: string
+}
+
+const favoriteRepoItem = (repo: Repo | RepoSingle): FavoriteRepoItem => ({
+  id: repo.id,
+  full_name: repo.full_name,
+  html_url: repo.html_url,
+  avatar_url: repo.owner?.avatar_url
+})
+
+export default function useFavorites(): UseFavorites {
+  const [favoriteRepos, setFavoriteRepos] = useState<FavoriteRepoItem[]>([])
+  const prevSizeRef = useRef<number>(0)
+
+  useEffect(() => {
+    const sizeDiff = favoriteRepos.length - prevSizeRef.current
+
+    async function storeFavorites() {
+      const value = JSON.stringify(favoriteRepos)
+      await LocalStorage.setItem(KEY, value)
+      if (sizeDiff < 0) {
+        await showToast({
+          style: Toast.Style.Success,
+          title: 'Success!',
+          message: 'Repo removed from favorites.'
+        })
+      }
+    }
+
+    if (sizeDiff !== 0) {
+      storeFavorites()
+      prevSizeRef.current = favoriteRepos.length
+    }
+  }, [favoriteRepos])
+
+  useEffect(() => {
+    async function getFavoritesFromStorage() {
+      const value = (await LocalStorage.getItem(KEY)) as string
+      if (value) {
+        setFavoriteRepos(JSON.parse(value) || [])
+      }
+    }
+    getFavoritesFromStorage()
+  }, [])
+
+  const isFavoritable = useCallback(
+    query =>
+      /.+\/.+/.test(query) &&
+      !favoriteRepos.some(item => item.full_name === query),
+    [favoriteRepos]
+  )
+
+  const isFavorite = useCallback(
+    (repo: Repo): boolean => {
+      return favoriteRepos.some(item => item.id === repo.id)
+    },
+    [favoriteRepos]
+  )
+
+  const addFavorite = useCallback(
+    repo => {
+      const repoToAdd = favoriteRepoItem(repo)
+      setFavoriteRepos(favoriteRepos.concat(repoToAdd))
+    },
+    [favoriteRepos]
+  )
+
+  const addFavoriteFromQuery = useCallback(
+    async query => {
+      try {
+        const [owner, repo] = query.trim().split('/')
+        await showToast({
+          style: Toast.Style.Animated,
+          title: `Trying to fetch ${query}...`
+        })
+        const repoResult = await octokit.rest.repos.get({owner, repo})
+        addFavorite(repoResult.data)
+        await showToast({
+          style: Toast.Style.Success,
+          title: 'Success!',
+          message: `${query} has been added to favorites.`
+        })
+      } catch (error) {
+        const httpError = error as HttpError
+        await showToast({
+          style: Toast.Style.Failure,
+          title: httpError.status.toString(),
+          message: `Error fetching ${query}: ${httpError.message}`
+        })
+      }
+    },
+    [addFavorite]
+  )
+
+  const removeFavorite = useCallback(
+    repo => {
+      setFavoriteRepos(favoriteRepos.filter(item => item.id !== repo.id))
+    },
+    [favoriteRepos]
+  )
+
+  return {
+    addFavorite,
+    addFavoriteFromQuery,
+    favoriteRepos,
+    isFavorite,
+    isFavoritable,
+    removeFavorite
+  }
+}

--- a/src/hooks/use-favorites.tsx
+++ b/src/hooks/use-favorites.tsx
@@ -4,15 +4,16 @@ import {useState, useEffect, useRef, useCallback} from 'react'
 import {octokit} from '../lib/octokit'
 import {Repo} from '../search-repos'
 
-type RepoSingle = RestEndpointMethodTypes['repos']['get']['response']['data']
+export type RepoSingle =
+  RestEndpointMethodTypes['repos']['get']['response']['data']
 
 const KEY = 'favorite-repos'
 
 type UseFavorites = {
-  addFavorite: (repo: Repo | RepoSingle) => void
+  addFavorite: (repo: Repo | RepoSingle | FavoriteRepoItem) => void
   addFavoriteFromQuery: (query: string) => void
   favoriteRepos: FavoriteRepoItem[]
-  isFavorite: (repo: Repo) => boolean
+  isFavorite: (repo: Repo | RepoSingle | FavoriteRepoItem) => boolean
   isFavoritable: (query: string) => boolean
   removeFavorite: (repo: Repo | FavoriteRepoItem) => void
 }
@@ -29,7 +30,9 @@ export type FavoriteRepoItem = {
   avatar_url?: string
 }
 
-const favoriteRepoItem = (repo: Repo | RepoSingle): FavoriteRepoItem => ({
+export const favoriteRepoItem = (
+  repo: Repo | RepoSingle
+): FavoriteRepoItem => ({
   id: repo.id,
   full_name: repo.full_name,
   html_url: repo.html_url,
@@ -79,7 +82,7 @@ export default function useFavorites(): UseFavorites {
   )
 
   const isFavorite = useCallback(
-    (repo: Repo): boolean => {
+    repo => {
       return favoriteRepos.some(item => item.id === repo.id)
     },
     [favoriteRepos]

--- a/src/manage-favorites.tsx
+++ b/src/manage-favorites.tsx
@@ -2,11 +2,14 @@ import {
   ActionPanel,
   CopyToClipboardAction,
   List,
-  OpenInBrowserAction
+  OpenInBrowserAction,
+  PushAction
 } from '@raycast/api'
 import {ReactElement, useCallback, useState, FC} from 'react'
+import RepoDetail from './components/repo-detail'
 import useFavorites, {FavoriteRepoItem} from './hooks/use-favorites'
 import icon from './lib/icon'
+import {RepoActions} from './search-repos'
 
 type FavoritesActionsProps = {
   repo: FavoriteRepoItem
@@ -32,6 +35,7 @@ const GitHubManageFavorites: FC = () => {
         key={repo.id}
         title={repo.full_name}
         icon={repo.avatar_url}
+        detail={<FavoriteDetail repo={repo} />}
         actions={
           <FavoritesActions
             repo={repo}
@@ -59,14 +63,51 @@ const GitHubManageFavorites: FC = () => {
     )
   }
 
+  const isShowingDetail = !!favoriteRepos.length && !!ListItems.length
+
   return (
-    <List searchText={query} onSearchTextChange={setQuery}>
-      {ListItems}
+    <List
+      searchText={query}
+      onSearchTextChange={setQuery}
+      isShowingDetail={isShowingDetail}
+    >
+      {ListItems.length ? (
+        ListItems
+      ) : (
+        <List.EmptyView
+          icon={icon('heart')}
+          title="No favorites found!"
+          description="Type repo/owner to add one. For example: raycast/extensions."
+        />
+      )}
     </List>
   )
 }
 
 export default GitHubManageFavorites
+
+type FavoriteDetailProps = {
+  repo: FavoriteRepoItem
+}
+
+function FavoriteDetail({repo}: FavoriteDetailProps): ReactElement {
+  return (
+    <List.Item.Detail
+      markdown={`![${repo.full_name}](${repo.avatar_url})`}
+      metadata={
+        <List.Item.Detail.Metadata>
+          {Object.entries(repo).map(([key, val]) => (
+            <List.Item.Detail.Metadata.Label
+              key={key}
+              title={key}
+              text={val?.toString()}
+            />
+          ))}
+        </List.Item.Detail.Metadata>
+      }
+    />
+  )
+}
 
 function NewFavoriteActions({
   query,
@@ -103,6 +144,16 @@ function FavoritesActions({
         title="Remove from favorites"
         onAction={onRemove}
         icon={icon('heart')}
+      />
+      <PushAction
+        title="View details"
+        target={
+          <RepoDetail
+            repo={repo.full_name}
+            actions={<RepoActions item={repo} />}
+          />
+        }
+        icon={icon('info')}
       />
       <OpenInBrowserAction
         title="Open in browser"

--- a/src/manage-favorites.tsx
+++ b/src/manage-favorites.tsx
@@ -1,0 +1,119 @@
+import {
+  ActionPanel,
+  CopyToClipboardAction,
+  List,
+  OpenInBrowserAction
+} from '@raycast/api'
+import {ReactElement, useCallback, useState, FC} from 'react'
+import useFavorites, {FavoriteRepoItem} from './hooks/use-favorites'
+import icon from './lib/icon'
+
+type FavoritesActionsProps = {
+  repo: FavoriteRepoItem
+  onAction: (repo: FavoriteRepoItem) => void
+  setQuery: (query: string) => void
+}
+
+type NewFavoritesActionsProps = {
+  query: string
+  onAction: (query: string) => void
+  setQuery: (query: string) => void
+}
+
+const GitHubManageFavorites: FC = () => {
+  const {favoriteRepos, addFavoriteFromQuery, isFavoritable, removeFavorite} =
+    useFavorites()
+  const [query, setQuery] = useState('')
+
+  const ListItems = favoriteRepos
+    .filter(repo => !query.trim() || ~repo.full_name.indexOf(query))
+    .map(repo => (
+      <List.Item
+        key={repo.id}
+        title={repo.full_name}
+        icon={repo.avatar_url}
+        actions={
+          <FavoritesActions
+            repo={repo}
+            onAction={removeFavorite}
+            setQuery={setQuery}
+          />
+        }
+      />
+    ))
+
+  if (query.trim() && isFavoritable(query)) {
+    ListItems.push(
+      <List.Item
+        icon={icon('heart-fill')}
+        key="new"
+        title={`Add ${query}`}
+        actions={
+          <NewFavoriteActions
+            query={query}
+            onAction={addFavoriteFromQuery}
+            setQuery={setQuery}
+          />
+        }
+      />
+    )
+  }
+
+  return (
+    <List searchText={query} onSearchTextChange={setQuery}>
+      {ListItems}
+    </List>
+  )
+}
+
+export default GitHubManageFavorites
+
+function NewFavoriteActions({
+  query,
+  onAction,
+  setQuery
+}: NewFavoritesActionsProps): ReactElement {
+  const onAdd = useCallback(() => {
+    onAction(query)
+    setQuery('')
+  }, [onAction, query, setQuery])
+  return (
+    <ActionPanel>
+      <ActionPanel.Item
+        title="Add to Favorites"
+        onAction={onAdd}
+        icon={icon('heart-fill')}
+      />
+    </ActionPanel>
+  )
+}
+
+function FavoritesActions({
+  repo,
+  onAction,
+  setQuery
+}: FavoritesActionsProps): ReactElement {
+  const onRemove = useCallback(() => {
+    onAction(repo)
+    setQuery('')
+  }, [onAction, repo, setQuery])
+  return (
+    <ActionPanel>
+      <ActionPanel.Item
+        title="Remove from favorites"
+        onAction={onRemove}
+        icon={icon('heart')}
+      />
+      <OpenInBrowserAction
+        title="Open in browser"
+        url={repo.html_url}
+        icon={icon('browser')}
+      />
+      <CopyToClipboardAction
+        title="Copy URL to clipboard"
+        content={repo.html_url}
+        shortcut={{modifiers: ['cmd', 'shift'], key: 'c'}}
+      />
+    </ActionPanel>
+  )
+}

--- a/src/search-code.tsx
+++ b/src/search-code.tsx
@@ -1,5 +1,9 @@
 import {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods'
-import {ActionPanel, OpenInBrowserAction} from '@raycast/api'
+import {
+  ActionPanel,
+  CopyToClipboardAction,
+  OpenInBrowserAction
+} from '@raycast/api'
 import {ReactElement} from 'react'
 import Search from './components/search'
 import icon from './lib/icon'
@@ -49,6 +53,11 @@ function CodeActions({item}: ActionsProps): ReactElement {
         )}`}
         icon={icon('code')}
         shortcut={{key: '.', modifiers: []}}
+      />
+      <CopyToClipboardAction
+        title="Copy URL to clipboard"
+        content={item.html_url}
+        shortcut={{modifiers: ['cmd', 'shift'], key: 'c'}}
       />
     </ActionPanel>
   )

--- a/src/search-commits.tsx
+++ b/src/search-commits.tsx
@@ -1,5 +1,9 @@
 import {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods'
-import {ActionPanel, OpenInBrowserAction} from '@raycast/api'
+import {
+  ActionPanel,
+  CopyToClipboardAction,
+  OpenInBrowserAction
+} from '@raycast/api'
 import {ReactElement} from 'react'
 import Search from './components/search'
 import icon from './lib/icon'
@@ -51,6 +55,11 @@ function CommitActions({item}: ActionsProps): ReactElement {
         )}`}
         icon={icon('code')}
         shortcut={{key: '.', modifiers: []}}
+      />
+      <CopyToClipboardAction
+        title="Copy URL to clipboard"
+        content={item.html_url}
+        shortcut={{modifiers: ['cmd', 'shift'], key: 'c'}}
       />
     </ActionPanel>
   )

--- a/src/search-github-issues.tsx
+++ b/src/search-github-issues.tsx
@@ -25,11 +25,12 @@ interface ActionsProps {
   query: string
 }
 
-const IssueSearch: VFC = () => (
+const GitHubIssueSearch: VFC = () => (
   <Search<Issue>
     queryKey={query => ['search', 'commits', query]}
     queryFn={async q => {
-      const resp = await octokit.search.issuesAndPullRequests({q})
+      const query = `org:github ${q}`
+      const resp = await octokit.search.issuesAndPullRequests({q: query})
       const repos = resp.data.items
       return repos
     }}
@@ -59,7 +60,7 @@ const IssueSearch: VFC = () => (
   />
 )
 
-export default IssueSearch
+export default GitHubIssueSearch
 
 const NoQuery: VFC<{setQuery: (query: string) => void}> = ({setQuery}) => {
   const {savedQueries, deleteSavedQuery} = useSavedQueries()

--- a/src/search-issues.tsx
+++ b/src/search-issues.tsx
@@ -12,7 +12,7 @@ import {
   PushAction,
   setLocalStorageItem
 } from '@raycast/api'
-import {FC, useEffect, useState, VFC} from 'react'
+import {FC, useEffect, useState, VFC, ReactElement} from 'react'
 import Search from './components/search'
 import icon from './lib/icon'
 import {octokit} from './lib/octokit'
@@ -64,51 +64,35 @@ const IssueSearch: VFC = () => {
 export default IssueSearch
 
 type NoQueryProps = {
-  scopeByFavoriteRepos: boolean
   setQuery: (query: string) => void
-  toggleScopeOverride: () => void
+  searchBarAccessory: ReactElement
 }
 
-const NoQuery: VFC<NoQueryProps> = ({
-  setQuery,
-  scopeByFavoriteRepos,
-  toggleScopeOverride
-}) => {
+const NoQuery: VFC<NoQueryProps> = ({setQuery, searchBarAccessory}) => {
   const {savedQueries, deleteSavedQuery} = useSavedQueries()
 
-  const Actions = savedQueries.map((query, i) => (
-    <List.Item
-      key={i}
-      title={query}
-      actions={
-        <ActionPanel>
-          <ActionPanel.Item title="Search" onAction={() => setQuery(query)} />
-          <ActionPanel.Item
-            title="Delete saved query"
-            onAction={() => deleteSavedQuery(query)}
-          />
-        </ActionPanel>
-      }
-    />
-  ))
-
-  Actions.push(
-    <List.Item
-      key="toggle"
-      title={
-        scopeByFavoriteRepos
-          ? 'Currently searching ❤️  favorite repos. Search all repos instead...'
-          : 'Currently searching all repos. Search ❤️  favorites instead...'
-      }
-      actions={
-        <ActionPanel>
-          <ActionPanel.Item title="Toggle" onAction={toggleScopeOverride} />
-        </ActionPanel>
-      }
-    />
+  return (
+    <List searchBarAccessory={searchBarAccessory} onSearchTextChange={setQuery}>
+      {savedQueries.map((query, i) => (
+        <List.Item
+          key={i}
+          title={query}
+          actions={
+            <ActionPanel>
+              <ActionPanel.Item
+                title="Search"
+                onAction={() => setQuery(query)}
+              />
+              <ActionPanel.Item
+                title="Delete saved query"
+                onAction={() => deleteSavedQuery(query)}
+              />
+            </ActionPanel>
+          }
+        />
+      ))}
+    </List>
   )
-
-  return <List onSearchTextChange={setQuery}>{Actions}</List>
 }
 
 const issueIcon = (issue: Issue): ImageLike => {

--- a/src/search-repos.tsx
+++ b/src/search-repos.tsx
@@ -1,10 +1,16 @@
 import proc from 'child_process'
 import {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods'
-import {ActionPanel, OpenInBrowserAction, PushAction} from '@raycast/api'
+import {
+  ActionPanel,
+  CopyToClipboardAction,
+  OpenInBrowserAction,
+  PushAction
+} from '@raycast/api'
 import {ReactElement} from 'react'
 import {Codespace} from './codespaces'
 import RepoDetail from './components/repo-detail'
 import Search from './components/search'
+import useFavorites from './hooks/use-favorites'
 import icon from './lib/icon'
 import {octokit} from './lib/octokit'
 
@@ -36,6 +42,14 @@ export default function RepoSearch(): ReactElement {
 }
 
 function RepoActions({item}: ActionsProps): ReactElement {
+  const {isFavorite, addFavorite, removeFavorite} = useFavorites()
+  const isFavoriteRepo = isFavorite(item)
+  const favoriteTitle = `${isFavoriteRepo ? 'Remove from' : 'Add to'} favorites`
+  const favoriteAction = () => {
+    isFavoriteRepo ? removeFavorite(item) : addFavorite(item)
+  }
+  const favoriteIcon = isFavoriteRepo ? 'heart-fill' : 'heart'
+
   const openOrCreateCodespace = async () => {
     const codespaces: Codespace[] = (
       await octokit.request(`GET /user/codespaces`)
@@ -79,6 +93,12 @@ function RepoActions({item}: ActionsProps): ReactElement {
         }
       />
 
+      <CopyToClipboardAction
+        title="Copy URL to clipboard"
+        content={item.html_url}
+        shortcut={{modifiers: ['cmd', 'shift'], key: 'c'}}
+      />
+
       <OpenInBrowserAction
         title="Open issues in browser"
         url={`${item.html_url}/issues`}
@@ -102,6 +122,11 @@ function RepoActions({item}: ActionsProps): ReactElement {
         title="Open or create Codespace"
         onAction={openOrCreateCodespace}
         icon={icon('codespaces')}
+      />
+      <ActionPanel.Item
+        title={favoriteTitle}
+        onAction={favoriteAction}
+        icon={icon(favoriteIcon)}
       />
     </ActionPanel>
   )

--- a/src/search-repos.tsx
+++ b/src/search-repos.tsx
@@ -10,7 +10,7 @@ import {ReactElement} from 'react'
 import {Codespace} from './codespaces'
 import RepoDetail from './components/repo-detail'
 import Search from './components/search'
-import useFavorites from './hooks/use-favorites'
+import useFavorites, {FavoriteRepoItem} from './hooks/use-favorites'
 import icon from './lib/icon'
 import {octokit} from './lib/octokit'
 
@@ -18,7 +18,7 @@ export type Repo =
   RestEndpointMethodTypes['search']['repos']['response']['data']['items'][number]
 
 interface ActionsProps {
-  item: Repo
+  item: Repo | FavoriteRepoItem
 }
 
 export default function RepoSearch(): ReactElement {
@@ -41,7 +41,7 @@ export default function RepoSearch(): ReactElement {
   )
 }
 
-function RepoActions({item}: ActionsProps): ReactElement {
+export function RepoActions({item}: ActionsProps): ReactElement {
   const {isFavorite, addFavorite, removeFavorite} = useFavorites()
   const isFavoriteRepo = isFavorite(item)
   const favoriteTitle = `${isFavoriteRepo ? 'Remove from' : 'Add to'} favorites`

--- a/src/search-users.tsx
+++ b/src/search-users.tsx
@@ -1,5 +1,10 @@
 import {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods'
-import {ActionPanel, OpenInBrowserAction, PushAction} from '@raycast/api'
+import {
+  ActionPanel,
+  CopyToClipboardAction,
+  OpenInBrowserAction,
+  PushAction
+} from '@raycast/api'
 import {ReactElement} from 'react'
 import RepoDetail from './components/repo-detail'
 import Search from './components/search'
@@ -49,6 +54,12 @@ function Actions({item}: ActionsProps): ReactElement {
             actions={<Actions item={item} />}
           />
         }
+      />
+
+      <CopyToClipboardAction
+        title="Copy URL to clipboard"
+        content={item.html_url}
+        shortcut={{modifiers: ['cmd', 'shift'], key: 'c'}}
       />
     </ActionPanel>
   )


### PR DESCRIPTION
This PR adds a scope dropdown for all queries, refining search to all repos, GitHub org, or favorites:

https://user-images.githubusercontent.com/526284/174573830-68d51413-1799-45ad-a228-20ea20162c85.mp4

It also adds functionality in support of "favorites," enabling users to add/remove favorite repos via an action on repo search results and also via a dedicated "Manage Favorite Repos" command:

https://user-images.githubusercontent.com/526284/174573380-4002d24d-b1ce-4d63-860f-34893411e741.mp4

